### PR TITLE
Go monochrome and fix relative URLs

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,10 @@ publish = "public"
 
 [build.environment]
 HUGO_VERSION = "0.154.5"
+NODE_VERSION = "18"
 
 [context.production.environment]
 HUGO_ENV = "production"
+
+[images]
+node_bundler = "esbuild"

--- a/themes/gokhan-noir/assets/css/main.css
+++ b/themes/gokhan-noir/assets/css/main.css
@@ -12,8 +12,8 @@
   --text-primary: #FFFFFF;
   --text-secondary: #B0B0B0;
   --text-tertiary: #707070;
-  --accent: #4ADE80;
-  --accent-hover: #22C55E;
+  --accent: #FFFFFF;
+  --accent-hover: #D4D4D4;
   --border: #262626;
   --code-bg: #111111;
 
@@ -55,8 +55,8 @@
   --text-primary: #111827;
   --text-secondary: #6B7280;
   --text-tertiary: #9CA3AF;
-  --accent: #16A34A;
-  --accent-hover: #15803D;
+  --accent: #111827;
+  --accent-hover: #4B5563;
   --border: #E5E7EB;
   --code-bg: #F3F4F6;
 }
@@ -124,14 +124,16 @@ p {
 }
 
 a {
-  color: var(--accent);
-  text-decoration: none;
-  transition: color var(--transition-fast);
+  color: var(--text-primary);
+  text-decoration: underline;
+  text-decoration-color: var(--text-tertiary);
+  text-underline-offset: 3px;
+  text-decoration-thickness: 1px;
+  transition: text-decoration-color var(--transition-fast);
 }
 
 a:hover {
-  color: var(--accent-hover);
-  text-decoration: underline;
+  text-decoration-color: var(--text-primary);
 }
 
 strong {
@@ -139,7 +141,7 @@ strong {
 }
 
 blockquote {
-  border-left: 3px solid var(--accent);
+  border-left: 3px solid var(--text-tertiary);
   padding-left: var(--space-6);
   margin: var(--space-6) 0;
   color: var(--text-secondary);
@@ -182,7 +184,7 @@ code {
   background-color: var(--bg-tertiary);
   padding: 0.15em 0.4em;
   border-radius: var(--radius-sm);
-  color: var(--accent);
+  color: var(--text-primary);
 }
 
 pre {
@@ -236,7 +238,7 @@ pre:hover .copy-btn,
 }
 
 .copy-btn.copied {
-  color: var(--accent);
+  color: var(--text-primary);
 }
 
 /* --- Tables --- */
@@ -319,7 +321,7 @@ tr:hover td {
 }
 
 .nav-logo:hover {
-  color: var(--accent);
+  color: var(--text-secondary);
   text-decoration: none;
 }
 
@@ -520,7 +522,7 @@ tr:hover td {
 }
 
 .about-text a {
-  color: var(--accent);
+  color: var(--text-primary);
 }
 
 /* --- Tech Stack Grid --- */
@@ -547,7 +549,7 @@ tr:hover td {
 }
 
 .stack-item:hover {
-  border-color: var(--accent);
+  border-color: var(--text-secondary);
 }
 
 .stack-item-label {
@@ -555,7 +557,7 @@ tr:hover td {
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: var(--accent);
+  color: var(--text-primary);
   margin-bottom: var(--space-1);
 }
 
@@ -576,7 +578,7 @@ tr:hover td {
 
 .now-item {
   padding: var(--space-6);
-  border-left: 2px solid var(--accent);
+  border-left: 2px solid var(--text-tertiary);
 }
 
 .now-item-title {
@@ -612,7 +614,7 @@ tr:hover td {
 }
 
 .post-card:hover {
-  border-color: var(--accent);
+  border-color: var(--text-secondary);
   transform: translateY(-2px);
   text-decoration: none;
 }
@@ -631,9 +633,9 @@ tr:hover td {
   text-transform: uppercase;
   letter-spacing: 0.05em;
   padding: var(--space-1) var(--space-2);
-  border: 1px solid var(--accent);
+  border: 1px solid var(--text-tertiary);
   border-radius: var(--radius-sm);
-  color: var(--accent);
+  color: var(--text-secondary);
   line-height: 1;
 }
 
@@ -670,13 +672,14 @@ tr:hover td {
   gap: var(--space-2);
   font-size: 0.9375rem;
   font-weight: 500;
-  color: var(--accent);
+  color: var(--text-secondary);
   margin-top: var(--space-8);
-  transition: gap var(--transition-fast);
+  transition: gap var(--transition-fast), color var(--transition-fast);
 }
 
 .view-all:hover {
   gap: var(--space-3);
+  color: var(--text-primary);
   text-decoration: none;
 }
 
@@ -724,9 +727,9 @@ tr:hover td {
 }
 
 .filter-btn.active {
-  border-color: var(--accent);
-  color: var(--accent);
-  background-color: rgba(74, 222, 128, 0.08);
+  border-color: var(--text-primary);
+  color: var(--text-primary);
+  background-color: rgba(255, 255, 255, 0.06);
 }
 
 /* --- Single Post --- */
@@ -736,7 +739,7 @@ tr:hover td {
   left: 0;
   width: 0%;
   height: 2px;
-  background-color: var(--accent);
+  background-color: var(--text-primary);
   z-index: 200;
   transition: width 50ms linear;
 }
@@ -783,7 +786,7 @@ tr:hover td {
 }
 
 .post-tag:hover {
-  color: var(--accent);
+  color: var(--text-primary);
   text-decoration: none;
 }
 
@@ -796,7 +799,7 @@ tr:hover td {
 
 .post-body h2 {
   padding-left: var(--space-4);
-  border-left: 3px solid var(--accent);
+  border-left: 3px solid var(--text-tertiary);
 }
 
 .post-body img {
@@ -867,7 +870,7 @@ tr:hover td {
 }
 
 .project-card:hover {
-  border-color: var(--accent);
+  border-color: var(--text-secondary);
   transform: translateY(-2px);
 }
 
@@ -904,7 +907,7 @@ tr:hover td {
 .project-card-links a {
   font-size: 0.875rem;
   font-weight: 500;
-  color: var(--accent);
+  color: var(--text-secondary);
   display: inline-flex;
   align-items: center;
   gap: var(--space-1);
@@ -944,7 +947,7 @@ tr:hover td {
 }
 
 .experience-item:hover {
-  border-left-color: var(--accent);
+  border-left-color: var(--text-primary);
 }
 
 .experience-role {
@@ -953,7 +956,7 @@ tr:hover td {
 }
 
 .experience-company {
-  color: var(--accent);
+  color: var(--text-secondary);
 }
 
 .experience-period {
@@ -983,7 +986,7 @@ tr:hover td {
 }
 
 .elsewhere-links a:hover {
-  color: var(--accent);
+  color: var(--text-primary);
   text-decoration: none;
 }
 
@@ -1023,7 +1026,7 @@ tr:hover td {
 
 .page-404 h1 {
   font-size: 6rem;
-  color: var(--accent);
+  color: var(--text-primary);
   margin-bottom: var(--space-4);
 }
 

--- a/themes/gokhan-noir/layouts/404.html
+++ b/themes/gokhan-noir/layouts/404.html
@@ -8,7 +8,7 @@
   <p>
     {{ .Site.Params.subtitle404 | default "The page you're looking for doesn't exist." }}
   </p>
-  <a href="{{ .Site.BaseURL }}" style="display: inline-block; margin-top: var(--space-8); font-weight: 500;">
+  <a href="{{ "/" | relURL }}" style="display: inline-block; margin-top: var(--space-8); font-weight: 500;">
     &larr; Back to home
   </a>
 </div>

--- a/themes/gokhan-noir/layouts/_default/single.html
+++ b/themes/gokhan-noir/layouts/_default/single.html
@@ -35,13 +35,13 @@
   <div>
     {{ with .PrevInSection }}
     <span class="post-nav-label">Previous</span>
-    <a href="{{ .Permalink }}">{{ .Title }}</a>
+    <a href="{{ .RelPermalink }}">{{ .Title }}</a>
     {{ end }}
   </div>
   <div style="text-align: right;">
     {{ with .NextInSection }}
     <span class="post-nav-label">Next</span>
-    <a href="{{ .Permalink }}">{{ .Title }}</a>
+    <a href="{{ .RelPermalink }}">{{ .Title }}</a>
     {{ end }}
   </div>
 </nav>

--- a/themes/gokhan-noir/layouts/index.html
+++ b/themes/gokhan-noir/layouts/index.html
@@ -4,7 +4,7 @@
 <section class="hero">
   <h1 class="hero-name">Gökhan Çiflikli</h1>
   <p class="hero-title">Principal AI Engineer</p>
-  <p class="hero-tagline">Building Wellbeing Intelligence at <a href="https://www.healf.com/" style="color: var(--accent);">Healf</a>.</p>
+  <p class="hero-tagline">Building Wellbeing Intelligence at <a href="https://www.healf.com/">Healf</a>.</p>
   <p class="hero-tagline" style="margin-top: calc(-1 * var(--space-6)); color: var(--text-tertiary);">17 years in AI/ML. PhD. Research to production.</p>
   <div class="hero-social">
     {{ partial "social-icons.html" . }}

--- a/themes/gokhan-noir/layouts/partials/nav.html
+++ b/themes/gokhan-noir/layouts/partials/nav.html
@@ -1,6 +1,6 @@
 <nav class="nav" id="nav">
   <div class="nav-inner">
-    <a href="{{ .Site.BaseURL }}" class="nav-logo">GC</a>
+    <a href="{{ "/" | relURL }}" class="nav-logo">GC</a>
     <button class="nav-mobile-toggle" id="nav-toggle" aria-label="Toggle navigation">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
         <line x1="3" y1="6" x2="21" y2="6"></line>

--- a/themes/gokhan-noir/layouts/partials/post-card.html
+++ b/themes/gokhan-noir/layouts/partials/post-card.html
@@ -1,4 +1,4 @@
-<a href="{{ .Permalink }}" class="post-card">
+<a href="{{ .RelPermalink }}" class="post-card">
   {{ with .Params.categories }}
   <div class="post-card-categories">
     {{ range . }}

--- a/themes/gokhan-noir/layouts/section/writing.html
+++ b/themes/gokhan-noir/layouts/section/writing.html
@@ -26,7 +26,7 @@
       {{ $posts = sort $posts ".Date" "desc" }}
 
       {{ range $posts }}
-      <a href="{{ .Permalink }}" class="post-card" data-categories="{{ delimit .Params.categories "," | lower }}">
+      <a href="{{ .RelPermalink }}" class="post-card" data-categories="{{ delimit .Params.categories "," | lower }}">
         {{ with .Params.categories }}
         <div class="post-card-categories">
           {{ range . }}

--- a/themes/gokhan-noir/layouts/taxonomy/tags.html
+++ b/themes/gokhan-noir/layouts/taxonomy/tags.html
@@ -8,7 +8,7 @@
   <div class="container">
     <div class="filters" style="max-width: var(--max-prose); margin: 0 auto;">
       {{ range .Data.Terms.Alphabetical }}
-      <a href="{{ .Page.Permalink }}" class="filter-btn" style="text-decoration: none;">
+      <a href="{{ .Page.RelPermalink }}" class="filter-btn" style="text-decoration: none;">
         {{ .Page.Title }} <span style="color: var(--text-tertiary);">({{ .Count }})</span>
       </a>
       {{ end }}


### PR DESCRIPTION
## Summary
- Drop green accent — full monochrome palette (black, white, grey only)
- Links use subtle grey underlines instead of colour, brightening to white on hover
- Fix all navigable links to use `.RelPermalink` / `relURL` so they resolve correctly on both localhost and production
- Keep absolute URLs only in `<head>` meta tags and RSS (correct for SEO/feeds)

## Test plan
- [x] Verify no green remains in the UI
- [x] Verify all internal links navigate correctly (no redirect to production from localhost)
- [x] Verify hover states work on links, cards, nav
- [x] Verify Netlify deploy succeeds on Ubuntu 24.04

🤖 Generated with [Claude Code](https://claude.com/claude-code)