### PR TITLE
Add GC monogram SVG favicon

### DIFF
--- a/static/favicon.svg
+++ b/static/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="4" fill="#0A0A0A"/>
+  <text x="16" y="22.5" font-family="Inter, -apple-system, BlinkMacSystemFont, sans-serif" font-size="15" font-weight="900" fill="#FFFFFF" text-anchor="middle" letter-spacing="-0.5">GC</text>
+</svg>

--- a/themes/gokhan-noir/layouts/partials/head.html
+++ b/themes/gokhan-noir/layouts/partials/head.html
@@ -27,7 +27,7 @@
 {{ end -}}
 
 {{/* Favicon */}}
-<link rel="icon" href="{{ "favicon.ico" | relURL }}">
+<link rel="icon" type="image/svg+xml" href="{{ "favicon.svg" | relURL }}">
 
 {{/* Fonts */}}
 <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
Black rounded square with bold white "GC" matching the nav logo. SVG for crisp rendering at any size.