### PR TITLE
Monochrome polish, favicon, and resume rename

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -48,6 +48,6 @@ ignoreFiles = ["\\.Rmd$", "\\.Rmarkdown$", "\\.knit\\.md$", "\\.utf8\\.md$", "_c
     url = "/projects/"
     weight = 2
   [[menu.main]]
-    name = "About"
+    name = "Resume"
     url = "/about/"
     weight = 3

--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -1,8 +1,4 @@
 ---
-title: "About"
+title: "Resume"
 layout: "about"
 ---
-
-A methodologist and computational social scientist by training, I have 17 years of experience working in tech, open-source software development, and applied research. I hold a PhD from the London School of Economics where I maintain ongoing connections as a Visiting Senior Fellow at the [Data Science Institute](https://www.lse.ac.uk/DSI).
-
-I'm passionate about aligning technical work with the needs of the business to maximise the ROI on data initiatives. I enjoy mentoring data engineers, research scientists, and business analysts to accelerate their growth. I support and champion cognitive diversity, and since 2020 I assist the Tech Talent Charter to run and analyse their annual [Diversity in Tech surveys](https://report.techtalentcharter.co.uk/diversity-in-tech).

--- a/themes/gokhan-noir/layouts/partials/nav.html
+++ b/themes/gokhan-noir/layouts/partials/nav.html
@@ -11,7 +11,7 @@
     <ul class="nav-links" id="nav-links">
       <li><a href="{{ "writing/" | relURL }}" {{ if or (eq .Section "post") (eq .Section "python") (eq .Section "writing") }}class="active"{{ end }}>Writing</a></li>
       <li><a href="{{ "projects/" | relURL }}" {{ if eq .Section "projects" }}class="active"{{ end }}>Projects</a></li>
-      <li><a href="{{ "about/" | relURL }}" {{ if eq .Section "about" }}class="active"{{ end }}>About</a></li>
+      <li><a href="{{ "about/" | relURL }}" {{ if eq .Section "about" }}class="active"{{ end }}>Resume</a></li>
       <li>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">

--- a/themes/gokhan-noir/layouts/section/about.html
+++ b/themes/gokhan-noir/layouts/section/about.html
@@ -4,11 +4,6 @@
   <h1>{{ .Title }}</h1>
 
   <div class="about-section">
-    {{ .Content }}
-  </div>
-
-  <div class="about-section">
-    <h2>Experience</h2>
     <div class="experience-item">
       <div class="experience-role">Principal AI Engineer</div>
       <div class="experience-company">Healf</div>


### PR DESCRIPTION
## Summary

- **Monochrome palette**: Removed green accent entirely; links now use underline-based differentiation instead of color. Dark mode uses white/grey, light mode uses charcoal/grey.
- **Bold typography**: Inter 800/900 weights, larger hero name (4.5rem), pure white text primary, loosened letter-spacing on hero.
- **GC monogram favicon**: SVG favicon matching the nav monogram.
- **Relative URL fixes**: Switched `.Permalink` → `.RelPermalink` and `.Site.BaseURL` → `relURL` across all navigable links (keeps absolute URLs in `<head>` meta/OG tags and RSS).
- **Resume rename**: "About" → "Resume" in nav, page title, and config. Dropped bio paragraphs, keeping only work experience and PhD.
- **SEO / indexing fixes**: 301 redirects for removed `/publications/` and `/talks/` sections, `noindex` on thin taxonomy pages, cleaned sitemap (60 → 19 URLs), added `robots.txt`.

## Commits

1. `a818a85` — Modernise site with custom gokhan-noir theme
2. `3220489` — Bold up typography: heavier weights, larger sizes, pure white text
3. `91d9a8c` — Go monochrome and fix relative URLs
4. `5e0ac58` — Add GC monogram SVG favicon
5. `b5f97f0` — Rename About to Resume and streamline page
6. `423f8c1` — Fix Google Search Console indexing issues

## Test plan

- [x] `hugo server` builds without errors
- [x] All nav links resolve to localhost (not production)
- [x] Dark/light mode toggle works with monochrome palette
- [x] Favicon renders as GC monogram in browser tab
- [x] Resume page shows experience + PhD only (no bio paragraphs)
- [x] Blog posts render correctly (code highlighting, images, HTML widgets)
- [x] Responsive layout at 375px, 768px, 1024px, 1440px
- [x] Netlify preview deploys successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)